### PR TITLE
fix(tui): format JSON numbers as integers to avoid scientific notation in URLs

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1346,6 +1346,14 @@ func payloadField(payload json.RawMessage, key string) string {
 	if !ok {
 		return ""
 	}
+	// JSON numbers unmarshal as float64; format large integers without
+	// scientific notation (e.g., workflow run IDs).
+	if f, ok := v.(float64); ok {
+		if f == float64(int64(f)) {
+			return fmt.Sprintf("%d", int64(f))
+		}
+		return fmt.Sprintf("%g", f)
+	}
 	return fmt.Sprintf("%v", v)
 }
 


### PR DESCRIPTION
## Summary
- Workflow run URLs were broken because large numeric IDs (e.g., `23845524552`) were formatted as `2.3845524552e+10` by `fmt.Sprintf("%v")`
- JSON `encoding/json` unmarshals all numbers as `float64` into `any` — `%v` uses scientific notation for large values
- Now detects integer-valued floats and formats with `%d`

## Test plan
- [ ] Open detail view on a `job.started` or `job.completed` event
- [ ] Press `o` to open the workflow URL — should be `.../actions/runs/23845524552` not `.../runs/2.384e+10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)